### PR TITLE
DAT-847 Surface coverage of changed files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: "Name of sbt-scoverage xml report to parse"
   minStatementCov:
     description: "minimum value of % statement coverage [0, 1]"
+  changedFiles:
+    description: "Files changed in a PR"
 outputs:
   statementCoverage:
     description: "% value of statement coverage"

--- a/main.py
+++ b/main.py
@@ -22,11 +22,11 @@ def __valid_threshold(threshold):
     return th
 
 
-def main(repo_name, pr_number, token, report_name, min_statement_coverage):
+def main(repo_name, pr_number, token, report_name, min_statement_coverage, changed_files):
 
     icon_mappings = config['render']['icon_mappings']
     threshold = __valid_threshold(min_statement_coverage)
-    report_coverage = process_report(report_name, threshold)
+    report_coverage = process_report(report_name, threshold, changed_files)
     comment = render_pr_comment(report_coverage, icon_mappings)
     publish_comment(token, repo_name, pr_number, comment)
 
@@ -41,5 +41,6 @@ if __name__ == "__main__":
     access_token = os.environ["INPUT_TOKEN"]
     report_file_name = os.environ["INPUT_FILE"]
     min_stmt_cov = os.environ["INPUT_MINSTATEMENTCOV"]
+    changed_fs = os.environ["INPUT_CHANGEDFILES"]
 
-    main(repo, issue_number, access_token, report_file_name, min_stmt_cov)
+    main(repo, issue_number, access_token, report_file_name, min_stmt_cov, changed_fs)

--- a/main/models.py
+++ b/main/models.py
@@ -1,14 +1,21 @@
 from dataclasses import dataclass
 from typing import List
+from enum import Enum
 
 
 # ======================================
 # Report processing
+class CoverageType(Enum):
+    OVERALL = 1
+    PACKAGE = 2
+    CHANGED_FILE = 3
+
+
 @dataclass
 class CoverageEntry:
     name: str
     result: float
-    is_package: bool
+    cov_type: CoverageType
     threshold: float = None
 
 
@@ -16,6 +23,7 @@ class CoverageEntry:
 class ReportCoverage:
     overall: CoverageEntry
     packages: List[CoverageEntry]
+    changed_files: List[CoverageEntry]
 
 
 # ======================================

--- a/main/process.py
+++ b/main/process.py
@@ -1,9 +1,9 @@
 import xml.etree.ElementTree as ElemTree
-from .models import CoverageEntry, ReportCoverage
+from typing import List
+from .models import CoverageType, CoverageEntry, ReportCoverage
 
 
-def process_report(report_file_name, threshold):
-
+def process_report(report_file_name, threshold, changed_files=[]):
     OVERALL_COVERAGE_LABEL = 'statement_coverage'
 
     # Read report
@@ -16,7 +16,7 @@ def process_report(report_file_name, threshold):
     overall_coverage = CoverageEntry(
         name=OVERALL_COVERAGE_LABEL,
         result=statement_coverage,
-        is_package=False,
+        cov_type=CoverageType.OVERALL,
         threshold=threshold
     )
 
@@ -27,10 +27,43 @@ def process_report(report_file_name, threshold):
         count = float(package.attrib['statement-count'])
         invoked = float(package.attrib['statements-invoked'])
         cov = invoked / count
-        result = CoverageEntry(package_name, cov, is_package=True)
+        result = CoverageEntry(package_name, cov, cov_type=CoverageType.PACKAGE)
         coverage_per_package.append(result)
+
+    # Changed files
+    coverage_per_changed_file = __process_changed_files(root, changed_files)
 
     return ReportCoverage(
         overall=overall_coverage,
-        packages=coverage_per_package
+        packages=coverage_per_package,
+        changed_files=coverage_per_changed_file
     )
+
+
+def __process_changed_files(report_root, changed_files: List[str]):
+    coverage_per_file = []
+    # In Scala, multiple classes/objects can co-exist in the same file.
+    # So to keep track of unique entries we concatenate file name with class/object name.
+    # This "unique" identity is referred to as a key in the code below.
+    keys_found = []
+    for package in report_root.findall('packages/package'):
+        for class_entry in package.findall('classes/class'):
+            file_name = class_entry.attrib['filename']
+            # Changed files not found in the coverage report wont be analyzed, as expected.
+            match = [f for f in changed_files if f.endswith(file_name)]
+            if len(match) > 0:
+                class_name = class_entry.attrib['name']
+                key = '-'.join([file_name, class_name])
+                if key not in keys_found:
+                    keys_found.append(key)
+                    entry_name = ' - '.join([
+                        file_name.split('/')[-1],
+                        class_name.split('.')[-1]
+                    ])
+                    count = float(class_entry.attrib['statement-count'])
+                    invoked = float(class_entry.attrib['statements-invoked'])
+                    cov = invoked / count
+                    result = CoverageEntry(entry_name, cov, cov_type=CoverageType.CHANGED_FILE)
+                    coverage_per_file.append(result)
+
+    return coverage_per_file

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 from main.process import process_report
-from main.models import CoverageEntry, ReportCoverage
+from main.models import CoverageType, CoverageEntry, ReportCoverage
 
 
 class TestProcess(unittest.TestCase):
@@ -17,18 +17,51 @@ class TestProcess(unittest.TestCase):
         overall_coverage = CoverageEntry(
             'statement_coverage',
             0.9502617801047121,
-            is_package=False,
+            cov_type=CoverageType.OVERALL,
             threshold=threshold
         )
         coverage_per_package = [
-            CoverageEntry('com.app.testproject', 0.9880952380952381, is_package=True),
-            CoverageEntry('com.app.testproject.config', 0.8518518518518519, is_package=True),
-            CoverageEntry('com.app.testproject.monitoring', 0.9655172413793104, is_package=True),
-            CoverageEntry('com.app.testproject.serde', 0.851063829787234, is_package=True),
+            CoverageEntry('com.app.testproject', 0.9880952380952381, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.config', 0.8518518518518519, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.monitoring', 0.9655172413793104, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.serde', 0.851063829787234, cov_type=CoverageType.PACKAGE),
         ]
         expected_results = ReportCoverage(
             overall=overall_coverage,
-            packages=coverage_per_package
+            packages=coverage_per_package,
+            changed_files=[]
+        )
+        self.assertEqual(results, expected_results)
+
+    def test_process_report_changed_files(self):
+        threshold = 0.99
+        changed_files = [
+            'src/main/scala/com/app/testproject/config/StorageConfig.scala',
+            'src/main/scala/com/app/testproject/Processor.scala',
+            'README.md'
+        ]
+        results = process_report(self.TEST_COVERAGE_FILE, threshold, changed_files)
+        overall_coverage = CoverageEntry(
+            'statement_coverage',
+            0.9502617801047121,
+            cov_type=CoverageType.OVERALL,
+            threshold=threshold
+        )
+        coverage_per_package = [
+            CoverageEntry('com.app.testproject', 0.9880952380952381, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.config', 0.8518518518518519, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.monitoring', 0.9655172413793104, cov_type=CoverageType.PACKAGE),
+            CoverageEntry('com.app.testproject.serde', 0.851063829787234, cov_type=CoverageType.PACKAGE),
+        ]
+        coverage_per_changed_file = [
+            CoverageEntry('Processor.scala - ProcessorLive', 0.9926470588235294, cov_type=CoverageType.CHANGED_FILE),
+            CoverageEntry('Processor.scala - Processor', 1.0, cov_type=CoverageType.CHANGED_FILE),
+            CoverageEntry('StorageConfig.scala - StorageConfig', 0.7037037037037037, cov_type=CoverageType.CHANGED_FILE)
+        ]
+        expected_results = ReportCoverage(
+            overall=overall_coverage,
+            packages=coverage_per_package,
+            changed_files=coverage_per_changed_file
         )
         self.assertEqual(results, expected_results)
 

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1,6 +1,6 @@
 import unittest
 from .config import config
-from main.models import ReportCoverage, CoverageEntry
+from main.models import CoverageType, ReportCoverage, CoverageEntry
 from main.render import render_pr_comment
 
 
@@ -10,17 +10,21 @@ class TestRender(unittest.TestCase):
 
     def test_render_pr_comment_pass_threshold(self):
         results = ReportCoverage(
-            overall=CoverageEntry('statement_coverage', 0.75, threshold=0.20, is_package=False),
+            overall=CoverageEntry('statement_coverage', 0.75, threshold=0.20, cov_type=CoverageType.OVERALL),
             packages=[
-                CoverageEntry('com.app.pk1', 0.9, is_package=True),
-                CoverageEntry('com.app.pk2', 0.6, is_package=True)
-            ]
+                CoverageEntry('com.app.pk1', 0.9, cov_type=CoverageType.PACKAGE),
+                CoverageEntry('com.app.pk2', 0.6, cov_type=CoverageType.PACKAGE)
+            ],
+            changed_files=[]
         )
         comment = render_pr_comment(results, self.ICON_MAPPINGS)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
             '|:-|:-:|:-:|',
             '|Statement Coverage|75.0|:white_check_mark:|',
+            '',
+            '|Changed File(s)|%|Status|',
+            '|:-|:-:|:-:|',
             '',
             '|Package Coverage|%|Status|',
             '|:-|:-:|:-:|',
@@ -31,11 +35,12 @@ class TestRender(unittest.TestCase):
 
     def test_render_pr_comment_fail_threshold(self):
         results = ReportCoverage(
-            overall=CoverageEntry('statement_coverage', 0.60, threshold=0.90, is_package=False),
+            overall=CoverageEntry('statement_coverage', 0.60, threshold=0.90, cov_type=CoverageType.OVERALL),
             packages=[
-                CoverageEntry('com.app.pk1', 0.7, is_package=True),
-                CoverageEntry('com.app.pk2', 0.5, is_package=True)
-            ]
+                CoverageEntry('com.app.pk1', 0.7, cov_type=CoverageType.PACKAGE),
+                CoverageEntry('com.app.pk2', 0.5, cov_type=CoverageType.PACKAGE)
+            ],
+            changed_files=[]
         )
         comment = render_pr_comment(results, self.ICON_MAPPINGS)
         expected_comment = self.__build_comment([
@@ -43,10 +48,41 @@ class TestRender(unittest.TestCase):
             '|:-|:-:|:-:|',
             '|Statement Coverage|60.0|:x:|',
             '',
+            '|Changed File(s)|%|Status|',
+            '|:-|:-:|:-:|',
+            '',
             '|Package Coverage|%|Status|',
             '|:-|:-:|:-:|',
             '|com.app.pk1|70.0||',
             '|com.app.pk2|50.0||'
+        ])
+        self.assertEqual(comment.msg, expected_comment)
+
+    def test_render_pr_comment_with_changed_files(self):
+        results = ReportCoverage(
+            overall=CoverageEntry('statement_coverage', 0.75, threshold=0.20, cov_type=CoverageType.OVERALL),
+            packages=[
+                CoverageEntry('com.app.pk1', 0.9, cov_type=CoverageType.PACKAGE),
+                CoverageEntry('com.app.pk2', 0.6, cov_type=CoverageType.PACKAGE)
+            ],
+            changed_files=[
+                CoverageEntry('File.scala - ClassX', 0.95, cov_type=CoverageType.CHANGED_FILE)
+            ]
+        )
+        comment = render_pr_comment(results, self.ICON_MAPPINGS)
+        expected_comment = self.__build_comment([
+            '|Overall|%|Status|',
+            '|:-|:-:|:-:|',
+            '|Statement Coverage|75.0|:white_check_mark:|',
+            '',
+            '|Changed File(s)|%|Status|',
+            '|:-|:-:|:-:|',
+            '|File.scala - ClassX|95.0||',
+            '',
+            '|Package Coverage|%|Status|',
+            '|:-|:-:|:-:|',
+            '|com.app.pk1|90.0||',
+            '|com.app.pk2|60.0||'
         ])
         self.assertEqual(comment.msg, expected_comment)
 


### PR DESCRIPTION
Would like to see a separate summary for changes files.
Instead of using the Github API to identify which files changed, this version simply expects the original PR to submit a list of changed files. This can be easily achieved and configured with an existing [action](https://github.com/marketplace/actions/get-all-changed-files).


|Overall|%|Status|
|:-|:-:|:-:|
|Statement Coverage|75.0|:white_check_mark:|

|Changed File(s)|%|Status|
|:-|:-:|:-:|
|File.scala - ClassX|95.0||

|Package Coverage|%|Status|
|:-|:-:|:-:|
|com.app.pk1|90.0||
|com.app.pk2|60.0||

