### PR TITLE
DAT-1205 Visual coverage

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,10 +31,11 @@ def parse_changed_files(changed_files_str):
 def main(repo_name, pr_number, token, report_name, min_statement_coverage, changed_files_str, include_package_coverage):
 
     icon_mappings = config['render']['icon_mappings']
+    coverage_score_mappings = config['render']['coverage_score_mappings']
     changed_files = parse_changed_files(changed_files_str)
     threshold = __valid_threshold(min_statement_coverage)
     report_coverage = process_report(report_name, threshold, changed_files)
-    comment = render_pr_comment(report_coverage, icon_mappings, include_package_coverage)
+    comment = render_pr_comment(report_coverage, icon_mappings, coverage_score_mappings, include_package_coverage)
     publish_comment(token, repo_name, pr_number, comment)
 
     # Output results for Github Actions

--- a/main.py
+++ b/main.py
@@ -30,12 +30,11 @@ def parse_changed_files(changed_files_str):
 
 def main(repo_name, pr_number, token, report_name, min_statement_coverage, changed_files_str, include_package_coverage):
 
-    icon_mappings = config['render']['icon_mappings']
-    coverage_score_mappings = config['render']['coverage_score_mappings']
+    render_config = config['render']
     changed_files = parse_changed_files(changed_files_str)
     threshold = __valid_threshold(min_statement_coverage)
     report_coverage = process_report(report_name, threshold, changed_files)
-    comment = render_pr_comment(report_coverage, icon_mappings, coverage_score_mappings, include_package_coverage)
+    comment = render_pr_comment(report_coverage, render_config, include_package_coverage)
     publish_comment(token, repo_name, pr_number, comment)
 
     # Output results for Github Actions

--- a/main/config.py
+++ b/main/config.py
@@ -7,6 +7,14 @@ config = {
             'failed': ':x:',                    # Had lower coverage than threshold
             'unknown': 'unknown',
             'na': ''                            # Don't want to include an icon
+        },
+
+        # Icons used to decorate individual coverage results (file, packages, etc).
+        "coverage_score_mappings": {
+            'good': ':green_circle:',
+            'ok': ':yellow_circle:',
+            'poor': ':red_circle:',
+            'na': ':question:'
         }
     }
 }

--- a/main/config.py
+++ b/main/config.py
@@ -2,7 +2,7 @@
 config = {
     'render': {
         # Internal mappings for markdown formatted icons/emojis
-        "icon_mappings": {
+        "coverage_status": {
             'passed': ':white_check_mark:',     # Had equal/higher coverage than threshold
             'failed': ':x:',                    # Had lower coverage than threshold
             'unknown': 'unknown',
@@ -10,7 +10,7 @@ config = {
         },
 
         # Icons used to decorate individual coverage results (file, packages, etc).
-        "coverage_score_mappings": {
+        "coverage_score": {
             'good': ':green_circle:',
             'ok': ':yellow_circle:',
             'poor': ':red_circle:',

--- a/main/render.py
+++ b/main/render.py
@@ -2,7 +2,9 @@ from .models import CommentRow, Comment
 from .models import CoverageType, ReportCoverage, CoverageEntry, CoverageSection, Table
 
 
-def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, include_package_coverage=True):
+# TODO: Combine "icon_mapping" and "coverage_score_mappings" in config object
+# TODO: rename config object params
+def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, coverage_score_mappings, include_package_coverage=True):
     overall_cov = report_coverage.overall
     packages_cov = report_coverage.packages
     changed_files_cov = report_coverage.changed_files
@@ -15,7 +17,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, include_pac
             CommentRow(
                 name=__get_printable_name(overall_cov.name),
                 value=overall_cov.result,
-                icon=__get_icon(overall_cov, icon_mapping)
+                icon=__get_icon(overall_cov, icon_mapping, coverage_score_mappings)
             )
         ]
     )
@@ -27,7 +29,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, include_pac
             CommentRow(
                 name=pkg.name,
                 value=pkg.result,
-                icon=__get_icon(pkg, icon_mapping)
+                icon=__get_icon(pkg, icon_mapping, coverage_score_mappings)
             )
         )
     package_section = CoverageSection(
@@ -43,7 +45,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, include_pac
             CommentRow(
                 name=file_cov.name,
                 value=file_cov.result,
-                icon=__get_icon(file_cov, icon_mapping)
+                icon=__get_icon(file_cov, icon_mapping, coverage_score_mappings)
             )
         )
     changed_files_section = CoverageSection(
@@ -65,10 +67,10 @@ def __get_printable_name(coverage_entry_name):
     return coverage_entry_name.title().replace("_", " ")
 
 
-def __get_icon(coverage_entry: CoverageEntry, icon_mapping):
+def __get_icon(coverage_entry: CoverageEntry, icon_mapping, coverage_score_mappings):
     result_icon = ""
     if coverage_entry.cov_type in (CoverageType.PACKAGE, CoverageType.CHANGED_FILE):
-        result_icon = icon_mapping['na']
+        result_icon = __get_coverage_score_icon(coverage_entry.result, coverage_score_mappings)
     elif coverage_entry.threshold is None:
         result_icon = icon_mapping['unknown']
     else:
@@ -76,11 +78,24 @@ def __get_icon(coverage_entry: CoverageEntry, icon_mapping):
     return result_icon
 
 
+def __get_coverage_score_icon(coverage_result: float, coverage_score_mappings):
+    score_icon = ""
+    if coverage_result >= 0.8:
+        score_icon = coverage_score_mappings['good']
+    elif coverage_result >= 0.4:
+        score_icon = coverage_score_mappings['ok']
+    elif coverage_result > 0:
+        score_icon = coverage_score_mappings['poor']
+    else:
+        score_icon = coverage_score_mappings['na']
+    return score_icon
+
+
 def __gen_table(section: CoverageSection):
 
     table_header = [
         section.headers,
-        '|:-|:-:|:-:|'
+        '|:-|-:|:-:|'
     ]
 
     table_entries = []

--- a/main/render.py
+++ b/main/render.py
@@ -2,9 +2,7 @@ from .models import CommentRow, Comment
 from .models import CoverageType, ReportCoverage, CoverageEntry, CoverageSection, Table
 
 
-# TODO: Combine "icon_mapping" and "coverage_score_mappings" in config object
-# TODO: rename config object params
-def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, coverage_score_mappings, include_package_coverage=True):
+def render_pr_comment(report_coverage: ReportCoverage, render_config, include_package_coverage=True):
     overall_cov = report_coverage.overall
     packages_cov = report_coverage.packages
     changed_files_cov = report_coverage.changed_files
@@ -17,7 +15,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, coverage_sc
             CommentRow(
                 name=__get_printable_name(overall_cov.name),
                 value=overall_cov.result,
-                icon=__get_icon(overall_cov, icon_mapping, coverage_score_mappings)
+                icon=__get_icon(overall_cov, render_config)
             )
         ]
     )
@@ -29,7 +27,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, coverage_sc
             CommentRow(
                 name=pkg.name,
                 value=pkg.result,
-                icon=__get_icon(pkg, icon_mapping, coverage_score_mappings)
+                icon=__get_icon(pkg, render_config)
             )
         )
     package_section = CoverageSection(
@@ -45,7 +43,7 @@ def render_pr_comment(report_coverage: ReportCoverage, icon_mapping, coverage_sc
             CommentRow(
                 name=file_cov.name,
                 value=file_cov.result,
-                icon=__get_icon(file_cov, icon_mapping, coverage_score_mappings)
+                icon=__get_icon(file_cov, render_config)
             )
         )
     changed_files_section = CoverageSection(
@@ -67,14 +65,14 @@ def __get_printable_name(coverage_entry_name):
     return coverage_entry_name.title().replace("_", " ")
 
 
-def __get_icon(coverage_entry: CoverageEntry, icon_mapping, coverage_score_mappings):
+def __get_icon(coverage_entry: CoverageEntry, render_config):
     result_icon = ""
     if coverage_entry.cov_type in (CoverageType.PACKAGE, CoverageType.CHANGED_FILE):
-        result_icon = __get_coverage_score_icon(coverage_entry.result, coverage_score_mappings)
+        result_icon = __get_coverage_score_icon(coverage_entry.result, render_config['coverage_score'])
     elif coverage_entry.threshold is None:
-        result_icon = icon_mapping['unknown']
+        result_icon = render_config['coverage_status']['unknown']
     else:
-        result_icon = icon_mapping['failed'] if (coverage_entry.result < coverage_entry.threshold) else icon_mapping['passed']
+        result_icon = render_config['coverage_status']['failed'] if (coverage_entry.result < coverage_entry.threshold) else render_config['coverage_status']['passed']
     return result_icon
 
 

--- a/test/config.py
+++ b/test/config.py
@@ -7,6 +7,14 @@ config = {
             'failed': ':x:',                    # Had lower coverage than threshold
             'unknown': 'unknown',
             'na': ''                            # Don't want to include an icon
+        },
+
+        # Icons used to decorate individual coverage results (file, packages, etc).
+        "coverage_score_mappings": {
+            'good': ':green_circle:',
+            'ok': ':yellow_circle:',
+            'poor': ':red_circle:',
+            'na': ':question:'
         }
     }
 }

--- a/test/config.py
+++ b/test/config.py
@@ -2,7 +2,7 @@
 config = {
     'render': {
         # Internal mappings for markdown formatted icons/emojis
-        "icon_mappings": {
+        "coverage_status": {
             'passed': ':white_check_mark:',     # Had equal/higher coverage than threshold
             'failed': ':x:',                    # Had lower coverage than threshold
             'unknown': 'unknown',
@@ -10,7 +10,7 @@ config = {
         },
 
         # Icons used to decorate individual coverage results (file, packages, etc).
-        "coverage_score_mappings": {
+        "coverage_score": {
             'good': ':green_circle:',
             'ok': ':yellow_circle:',
             'poor': ':red_circle:',

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,8 +6,7 @@ from main.render import render_pr_comment
 
 class TestRender(unittest.TestCase):
 
-    ICON_MAPPINGS = config['render']['icon_mappings']
-    COVERAGE_SCORE_MAPPINGS = config['render']['coverage_score_mappings']
+    RENDER_CONFIG = config['render']
 
     def test_render_pr_comment_pass_threshold(self):
         results = ReportCoverage(
@@ -18,7 +17,7 @@ class TestRender(unittest.TestCase):
             ],
             changed_files=[]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
+        comment = render_pr_comment(results, self.RENDER_CONFIG)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
             '|:-|-:|:-:|',
@@ -43,7 +42,7 @@ class TestRender(unittest.TestCase):
             ],
             changed_files=[]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
+        comment = render_pr_comment(results, self.RENDER_CONFIG)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
             '|:-|-:|:-:|',
@@ -70,7 +69,7 @@ class TestRender(unittest.TestCase):
                 CoverageEntry('File.scala - ClassX', 0.95, cov_type=CoverageType.CHANGED_FILE)
             ]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
+        comment = render_pr_comment(results, self.RENDER_CONFIG)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
             '|:-|-:|:-:|',
@@ -98,7 +97,7 @@ class TestRender(unittest.TestCase):
                 CoverageEntry('File.scala - ClassX', 0.95, cov_type=CoverageType.CHANGED_FILE)
             ]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS, include_package_coverage=False)
+        comment = render_pr_comment(results, self.RENDER_CONFIG, include_package_coverage=False)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
             '|:-|-:|:-:|',

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -7,6 +7,7 @@ from main.render import render_pr_comment
 class TestRender(unittest.TestCase):
 
     ICON_MAPPINGS = config['render']['icon_mappings']
+    COVERAGE_SCORE_MAPPINGS = config['render']['coverage_score_mappings']
 
     def test_render_pr_comment_pass_threshold(self):
         results = ReportCoverage(
@@ -17,19 +18,19 @@ class TestRender(unittest.TestCase):
             ],
             changed_files=[]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS)
+        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '|Statement Coverage|75|:white_check_mark:|',
             '',
             '|Changed File(s)|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '',
             '|Package Coverage|%|Status|',
-            '|:-|:-:|:-:|',
-            '|com.app.pk1|91||',
-            '|com.app.pk2|66||'
+            '|:-|-:|:-:|',
+            '|com.app.pk1|91|:green_circle:|',
+            '|com.app.pk2|66|:yellow_circle:|'
         ])
         self.assertEqual(comment.msg, expected_comment)
 
@@ -42,19 +43,19 @@ class TestRender(unittest.TestCase):
             ],
             changed_files=[]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS)
+        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '|Statement Coverage|60|:x:|',
             '',
             '|Changed File(s)|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '',
             '|Package Coverage|%|Status|',
-            '|:-|:-:|:-:|',
-            '|com.app.pk1|70||',
-            '|com.app.pk2|50||'
+            '|:-|-:|:-:|',
+            '|com.app.pk1|70|:yellow_circle:|',
+            '|com.app.pk2|50|:yellow_circle:|'
         ])
         self.assertEqual(comment.msg, expected_comment)
 
@@ -69,20 +70,20 @@ class TestRender(unittest.TestCase):
                 CoverageEntry('File.scala - ClassX', 0.95, cov_type=CoverageType.CHANGED_FILE)
             ]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS)
+        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '|Statement Coverage|75|:white_check_mark:|',
             '',
             '|Changed File(s)|%|Status|',
-            '|:-|:-:|:-:|',
-            '|File.scala - ClassX|95||',
+            '|:-|-:|:-:|',
+            '|File.scala - ClassX|95|:green_circle:|',
             '',
             '|Package Coverage|%|Status|',
-            '|:-|:-:|:-:|',
-            '|com.app.pk1|90||',
-            '|com.app.pk2|60||'
+            '|:-|-:|:-:|',
+            '|com.app.pk1|90|:green_circle:|',
+            '|com.app.pk2|60|:yellow_circle:|'
         ])
         self.assertEqual(comment.msg, expected_comment)
 
@@ -97,15 +98,15 @@ class TestRender(unittest.TestCase):
                 CoverageEntry('File.scala - ClassX', 0.95, cov_type=CoverageType.CHANGED_FILE)
             ]
         )
-        comment = render_pr_comment(results, self.ICON_MAPPINGS, include_package_coverage=False)
+        comment = render_pr_comment(results, self.ICON_MAPPINGS, self.COVERAGE_SCORE_MAPPINGS, include_package_coverage=False)
         expected_comment = self.__build_comment([
             '|Overall|%|Status|',
-            '|:-|:-:|:-:|',
+            '|:-|-:|:-:|',
             '|Statement Coverage|75|:white_check_mark:|',
             '',
             '|Changed File(s)|%|Status|',
-            '|:-|:-:|:-:|',
-            '|File.scala - ClassX|95||',
+            '|:-|-:|:-:|',
+            '|File.scala - ClassX|95|:green_circle:|',
         ])
         self.assertEqual(comment.msg, expected_comment)
 


### PR DESCRIPTION
 Right now tables and numbers are great but I want to quickly see lower coverage, if it exists. This will make it quick and easy to spot high/low coverage. A particular coverage "score" results in a corresponding colour. The rule/criteria is arbitrary and hardcoded in the code for now, but can certainly be make configurable in future revisions.

For example:


|Overall|%|Status|
|:-|-:|:-:|
|Statement Coverage|75|:white_check_mark:|

|Changed File(s)|%|Status|
|:-|-:|:-:|
|File.scala - ClassX|95|:green_circle:|

|Package Coverage|%|Status|
|:-|-:|:-:|
|com.app.pk1|90|:green_circle:|
|com.app.pk2|60|:yellow_circle:|
|com.app.pk3|20|:red_circle:|
|com.app.pk4|0|:question:|